### PR TITLE
add LanguageSwitchAction

### DIFF
--- a/susi_python/main.py
+++ b/susi_python/main.py
@@ -106,6 +106,9 @@ def generate_result(response):
             result['stop'] = action
         elif isinstance(action, MediaAction):
             result['media_action'] = action.type
+        elif isinstance(action, LanguageSwitchAction):
+            result['language'] = action.language
+            result['answer'] = action.expression
 
     return result
 

--- a/susi_python/models.py
+++ b/susi_python/models.py
@@ -94,6 +94,11 @@ class TableAction(BaseAction):
         # columns is a dictionary containing list of names of column to be displayed on client.
         self.columns = columns
 
+class LanguageSwitchAction(BaseAction):
+    def __init__(self, language, expression):
+        super().__init__()
+        self.language = language
+        self.expression = expression
 
 class MapAction(BaseAction):
     def __init__(self, latitude, longitude, zoom=None):

--- a/susi_python/response_parser.py
+++ b/susi_python/response_parser.py
@@ -3,7 +3,12 @@ from .models import *
 
 def get_action(jsn):
     if jsn['type'] == 'answer':
-        return AnswerAction(jsn['expression'])
+        # language switching action is not an explicit one, but
+        # implicit when the action contains the "language" tag
+        if "language" in jsn:
+            return LanguageSwitchAction(jsn['language'], jsn['expression'])
+        else:
+            return AnswerAction(jsn['expression'])
     elif jsn['type'] == 'table':
         return TableAction(jsn['columns'])
     elif jsn['type'] == 'map':


### PR DESCRIPTION
although susi_server does not send back an explicit language switch
action, we have to tell the susi clients (susi_linux) that the
language was switched (for TTS and STT). A language switch is
detected when the answer section contains the "language" tag.