### PR TITLE
Handle all planned actions in a query

### DIFF
--- a/susi_python/main.py
+++ b/susi_python/main.py
@@ -82,12 +82,11 @@ def generate_result(response):
     result = dict()
     actions = response.answer.actions
     data = response.answer.data
-
-    result['test'] = "Test_addition"
+    result["planned_actions"] = []
     for action in actions:
+        data = dict()
         if isinstance(action, AnswerAction):
             result['answer'] = action.expression
-            result['plan_delay'] = action.plan_delay
         elif isinstance(action, AudioAction):
             result['identifier'] = action.identifier
         elif isinstance(action, TableAction):
@@ -109,11 +108,17 @@ def generate_result(response):
         elif isinstance(action, MediaAction):
             result['media_action'] = action.type
         elif isinstance(action, LanguageSwitchAction):
-            result['language'] = action.language
-            result['answer'] = action.expression
+            if action.plan_delay != None:
+                data['language'] = action.language
+                data['answer'] = action.expression
+                data['plan_delay'] = action.plan_delay
+                data['plan_date'] = action.plan_date
+            else:
+                result['language'] = action.language
+                result['answer'] = action.expression
+        if data != {}:
+            result["planned_actions"].append(data)
 
-        #result['plan_delay'] = response.plan_delay
-        #result['plan_date'] = response.plan_date
 
     return result
 

--- a/susi_python/main.py
+++ b/susi_python/main.py
@@ -86,9 +86,19 @@ def generate_result(response):
     for action in actions:
         data = dict()
         if isinstance(action, AnswerAction):
-            result['answer'] = action.expression
+            if action.plan_delay != None and action.plan_date != None:
+                data['answer'] = action.expression
+                data['plan_delay'] = action.plan_delay
+                data['plan_date'] = action.plan_date
+            else:
+                result['answer'] = action.expression
         elif isinstance(action, AudioAction):
-            result['identifier'] = action.identifier
+            if action.plan_delay != None and action.plan_date != None:
+                data['identifier'] = action.identifier
+                data['plan_delay'] = action.plan_delay
+                data['plan_date'] = action.plan_date
+            else:
+                result['identifier'] = action.identifier
         elif isinstance(action, TableAction):
             result['table'] = Table(action.columns, data)
         elif isinstance(action, MapAction):
@@ -108,7 +118,7 @@ def generate_result(response):
         elif isinstance(action, MediaAction):
             result['media_action'] = action.type
         elif isinstance(action, LanguageSwitchAction):
-            if action.plan_delay != None:
+            if action.plan_delay != None and action.plan_date != None:
                 data['language'] = action.language
                 data['answer'] = action.expression
                 data['plan_delay'] = action.plan_delay

--- a/susi_python/main.py
+++ b/susi_python/main.py
@@ -83,9 +83,11 @@ def generate_result(response):
     actions = response.answer.actions
     data = response.answer.data
 
+    result['test'] = "Test_addition"
     for action in actions:
         if isinstance(action, AnswerAction):
             result['answer'] = action.expression
+            result['plan_delay'] = action.plan_delay
         elif isinstance(action, AudioAction):
             result['identifier'] = action.identifier
         elif isinstance(action, TableAction):
@@ -110,8 +112,8 @@ def generate_result(response):
             result['language'] = action.language
             result['answer'] = action.expression
 
-        result['plan_delay'] = response.plan_delay
-        result['plan_date'] = response.plan_date
+        #result['plan_delay'] = response.plan_delay
+        #result['plan_date'] = response.plan_date
 
     return result
 

--- a/susi_python/models.py
+++ b/susi_python/models.py
@@ -6,13 +6,6 @@ class QueryResponse:
         self.answer_time = json['answer_time']
         self.session = session
         self.answer = answer
-        #self.plan_delay = None
-        #self.plan_date = None
-        #for action in json["answers"][0]["actions"]:
-        #    if "plan_delay" in action.keys():
-        #        self.plan_delay = action["plan_delay"]
-        #    if "plan_date" in action.keys():
-        #        self.plan_date = action["plan_date"]
 
     def __repr__(self):
         return 'QueryResponse (query = %s , client_id = %s, ' \
@@ -90,8 +83,8 @@ class UnknownAction(BaseAction):
 
 
 class AnswerAction(BaseAction):
-    def __init__(self, expression):
-        super().__init__()
+    def __init__(self, expression, plan_delay = None, plan_date = None):
+        super().__init__(plan_delay,plan_date)
         self.expression = expression
 
 
@@ -103,7 +96,6 @@ class TableAction(BaseAction):
 
 class LanguageSwitchAction(BaseAction):
     def __init__(self, language, expression, plan_delay = None, plan_date = None):
-        print("LanguageSwitchAction", plan_delay, plan_date)
         super().__init__(plan_delay,plan_date)
         self.language = language
         self.expression = expression
@@ -144,8 +136,8 @@ class StopAction(BaseAction):
         super().__init__()
 
 class AudioAction(BaseAction):
-    def __init__(self, identifier , identifier_type):
-        super().__init__()
+    def __init__(self, identifier , identifier_type, plan_delay = None, plan_date = None):
+        super().__init__(plan_delay,plan_date)
         self.identifier = identifier
         self.identifier_type = identifier_type
 

--- a/susi_python/models.py
+++ b/susi_python/models.py
@@ -102,8 +102,9 @@ class TableAction(BaseAction):
         self.columns = columns
 
 class LanguageSwitchAction(BaseAction):
-    def __init__(self, language, expression):
-        super().__init__()
+    def __init__(self, language, expression, plan_delay = None, plan_date = None):
+        print("LanguageSwitchAction", plan_delay, plan_date)
+        super().__init__(plan_delay,plan_date)
         self.language = language
         self.expression = expression
 

--- a/susi_python/models.py
+++ b/susi_python/models.py
@@ -6,13 +6,13 @@ class QueryResponse:
         self.answer_time = json['answer_time']
         self.session = session
         self.answer = answer
-        self.plan_delay = None
-        self.plan_date = None
-        for action in json["answers"][0]["actions"]:
-            if "plan_delay" in action.keys():
-                self.plan_delay = action["plan_delay"]
-            if "plan_date" in action.keys():
-                self.plan_date = action["plan_date"]
+        #self.plan_delay = None
+        #self.plan_date = None
+        #for action in json["answers"][0]["actions"]:
+        #    if "plan_delay" in action.keys():
+        #        self.plan_delay = action["plan_delay"]
+        #    if "plan_date" in action.keys():
+        #        self.plan_date = action["plan_date"]
 
     def __repr__(self):
         return 'QueryResponse (query = %s , client_id = %s, ' \
@@ -79,8 +79,9 @@ class Metadata:
 
 
 class BaseAction:
-    def __init__(self):
-        pass
+    def __init__(self, plan_delay = None, plan_date = None):
+        self.plan_delay = plan_delay
+        self.plan_date = plan_date
 
 
 class UnknownAction(BaseAction):

--- a/susi_python/response_parser.py
+++ b/susi_python/response_parser.py
@@ -6,8 +6,12 @@ def get_action(jsn):
         # language switching action is not an explicit one, but
         # implicit when the action contains the "language" tag
         if "language" in jsn:
+            if 'plan_delay' in jsn.keys() and 'plan_date' in jsn.keys():
+                return LanguageSwitchAction(jsn['language'], jsn['expression'], jsn['plan_delay'], jsn['plan_date'])
             return LanguageSwitchAction(jsn['language'], jsn['expression'])
         else:
+            if 'plan_delay' in jsn.keys() and 'plan_date' in jsn.keys():
+                return AnswerAction(jsn['expression'], jsn['plan_delay'], jsn['plan_date'])
             return AnswerAction(jsn['expression'])
     elif jsn['type'] == 'table':
         return TableAction(jsn['columns'])
@@ -22,6 +26,8 @@ def get_action(jsn):
     elif jsn['type'] == 'stop':
         return StopAction()
     elif jsn['type'] == 'audio_play':
+        if 'plan_delay' in jsn.keys() and 'plan_date' in jsn.keys():
+            return AudioAction(jsn['identifier'], jsn['identifier_type'], jsn['plan_delay'], jsn['plan_date'])
         return AudioAction(jsn['identifier'], jsn['identifier_type'])
     elif jsn['type'] == 'audio_volume':
         return VolumeAction(jsn['volume'])


### PR DESCRIPTION
Fixes #12
### Solves
- Handle all planned actions in a query.

### Changes
-  A list of all planned actions from the server response is sent to the busy state, so that actions which are planned for later execution can be sent to the scheduler and actions which doesn't have any plan_delay or plan_date are executed instantly in Susi_Linux.

### Current Approach -
- Add `plan_delay` and `plan_date` to required action type object
- Check to see if an action is planned or not while parsing.
- If a action planned, append all such actions to a list.